### PR TITLE
sdcm.tester: Introduce the clean_aws_resources decorator

### DIFF
--- a/scylla_longevity.py
+++ b/scylla_longevity.py
@@ -2,6 +2,7 @@
 
 from avocado import main
 
+from sdcm.tester import clean_aws_resources
 from sdcm.tester import ScyllaClusterTester
 from sdcm.nemesis import ChaosMonkey
 


### PR DESCRIPTION
If something goes wrong (unhandled exceptions), we want
to make sure the AWS resources being used are cleaned up.
Let's do this with a clean_aws_resources decorator, that
specifically wraps a ScyllaClusterTester method, and upon
unhandled exception, cleans up resources and then re-raises
the original exception.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>