### PR TITLE
longevity_test: Add decommission test

### DIFF
--- a/scylla_longevity.py
+++ b/scylla_longevity.py
@@ -4,6 +4,7 @@ from avocado import main
 
 from sdcm.tester import ClusterTester
 from sdcm.nemesis import ChaosMonkey
+from sdcm.nemesis import DecommissionMonkey
 
 
 class LongevityTest(ClusterTester):
@@ -19,6 +20,11 @@ class LongevityTest(ClusterTester):
         Run a very short test, as a config/code sanity check.
         """
         self.db_cluster.add_nemesis(ChaosMonkey)
+        self.db_cluster.start_nemesis(interval=5)
+        self.run_stress(duration=20)
+
+    def test_20_minutes_decommission(self):
+        self.db_cluster.add_nemesis(DecommissionMonkey)
         self.db_cluster.start_nemesis(interval=5)
         self.run_stress(duration=20)
 

--- a/scylla_maintainance.py
+++ b/scylla_maintainance.py
@@ -45,3 +45,7 @@ class MaintainanceTest(ClusterTester):
         # the stop and restart
         self.db_cluster.start_nemesis(interval=10)
         self.run_stress(duration=20)
+
+
+if __name__ == '__main__':
+    main()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -348,6 +348,31 @@ class ScyllaCluster(Cluster):
                                                            ec2_user_data=ec2_user_data)
         return added_nodes
 
+    def get_node_info_list(self, verification_node):
+        assert verification_node in self.nodes
+        cmd_result = verification_node.remoter.run('nodetool status',
+                                                   timeout=120)
+        node_info_list = []
+        for line in cmd_result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith('UN'):
+                try:
+                    status, ip, load, _, tokens, owns, host_id, rack = line.split()
+                    node_info = {'status': status,
+                                 'ip': ip,
+                                 'load': load,
+                                 'tokens': tokens,
+                                 'owns': owns,
+                                 'host_id': host_id,
+                                 'rack': rack}
+                    node_info_list.append(node_info)
+                except ValueError:
+                    pass
+        # Cassandra banners have nodetool status output as well.
+        # Need to guarantee unique set of results.
+        node_info_list = list(set(node_info_list))
+        return node_info_list
+
     def wait_for_init(self, node_list=None, verbose=False):
         if node_list is None:
             node_list = self.nodes
@@ -375,8 +400,7 @@ class ScyllaCluster(Cluster):
                                          timeout=120)
                         raise NodeInitError(node=node, result=result)
                     except CmdError:
-                        run_cmd("sudo systemctl start scylla-server.service",
-                                timeout=120)
+                        pass
             initialized_nodes = len([node for node in node_initialized_map if
                                     node_initialized_map[node]])
             total_nodes = len(node_initialized_map.keys())

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -95,10 +95,12 @@ class RemoteCredentials(object):
             pass
         print("{}: Destroyed".format(str(self)))
 
+
 class Result(object):
 
     def __init__(self, stdout):
         self.stdout = stdout
+
 
 class Node(object):
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -44,6 +44,7 @@ class ChaosMonkey(Nemesis):
         time.sleep(60)
         self.node_to_operate.instance.start()
 
+
 class DrainerMonkey(Nemesis):
 
     def run(self, interval=30, termination_event=None):
@@ -57,6 +58,7 @@ class DrainerMonkey(Nemesis):
         time.sleep(60)
         self.node_to_operate.instance.start()
         self.node_to_operate.wait_for_init()
+
 
 class CorruptorMonkey(Nemesis):
 
@@ -92,6 +94,7 @@ class RepairMonkey(CorruptorMonkey):
 
     def repair(self):
         self.node_to_operate.remoter.run('nodetool -h localhost repair')
+
 
 class RebuildMonkey(CorruptorMonkey):
 


### PR DESCRIPTION
Add a nemesis that decommissions one of the test nodes,
then verifies if it was actually removed. Introduce
a test that uses said nemesis.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>